### PR TITLE
Add method of sharing using URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Place Keeper
 
-Map Sharing Application.
+Map Sharing Application with Just a Link.
 
 ## Overview
 
-Place Keeper is a convenient map-sharing application that allows users to pin locations on a map and share them with others using a unique code.  
-Owners can save and manage locations, while shared users can view them in a read-only format.
+Place Keeper is a web application that allows owners to create maps with pinned locations and share them via a unique URL.  
+No app installation or login is required for viewers—anyone with the link can access the shared map instantly.
 
 ### For Owners
 
@@ -16,13 +16,13 @@ Owners can save and manage locations, while shared users can view them in a read
 
 ### For Shared Users
 
--   **Access Shared Maps:** Enter the sharing code provided by the Owner to view the pinned locations.
+-   **No Login Required:** Just open the URL provided by the Owner to view the pinned locations.
 -   **Read-Only Mode:** Shared users can view locations but cannot add, edit, or delete them.
 
 ### Common Features
 
+-   **Pin List & Quick Jump:** Clicking a location in the list moves the map to the corresponding pin.
 -   **Search Functionality:** Quickly find saved locations using a search bar.
--   **Interactive Map Navigation:** Clicking a location in the list moves the map to the corresponding pin.
 -   **Route Display:** If multiple locations are saved, select them via checkboxes to display a route between them.
 
 ## Requirement
@@ -36,7 +36,7 @@ Owners can save and manage locations, while shared users can view them in a read
 | MariaDB            |  10.4.28 |
 | yarn               |  1.22.19 |
 
-## Usage
+## Local Usage
 
 ### Install Dependencies
 

--- a/src/components/PlaceTable.tsx
+++ b/src/components/PlaceTable.tsx
@@ -77,6 +77,7 @@ export const PlaceTable: NextPage<PlaceTableProps> = ({
                     setshowToastMessage={setShowToastMessage}
                     message={'Not Found Address'}
                     shouldReload={false}
+                    type="error"
                 />
             )}
             <div className="overflow-x-auto ml-3 mr-4">

--- a/src/components/Search.tsx
+++ b/src/components/Search.tsx
@@ -35,6 +35,7 @@ export const Search: NextPage<SearchProps> = ({ handleSearch }) => {
                         setshowToastMessage={setShowToastMessage}
                         message={'Invalid address.'}
                         shouldReload={false}
+                        type="error"
                     />
                 </div>
             )}

--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -3,9 +3,25 @@ import { useRouter } from 'next/router'
 import { ToastMessageProps } from '@/libs/interface/props'
 import styles from '@/styles/toast.module.css'
 
+const typeClassMap: Record<ToastMessageProps['type'], string> = {
+    success: 'bg-green-100 border-green-200 text-green-500',
+    error: 'bg-red-100 border-red-200 text-red-500',
+    info: 'bg-blue-100 border-blue-200 text-blue-500',
+    warning: 'bg-yellow-100 border-yellow-200 text-yellow-500',
+}
+
+const buttonColorMap: Record<ToastMessageProps['type'], string> = {
+    success: 'text-green-400 hover:text-green-600 focus:ring-green-400 focus:ring-offset-green-100',
+    error: 'text-red-400 hover:text-red-600 focus:ring-red-400 focus:ring-offset-red-100',
+    info: 'text-blue-400 hover:text-blue-600 focus:ring-blue-400 focus:ring-offset-blue-100',
+    warning:
+        'text-yellow-400 hover:text-yellow-600 focus:ring-yellow-400 focus:ring-offset-yellow-100',
+}
+
 export const ToastMessage: NextPage<ToastMessageProps> = ({
     setshowToastMessage,
     message,
+    type,
     shouldReload,
 }) => {
     const router = useRouter()
@@ -18,7 +34,7 @@ export const ToastMessage: NextPage<ToastMessageProps> = ({
     return (
         <div className={styles.toastContainer}>
             <div
-                className="max-w-xs bg-red-100 border border-red-200 text-sm text-red-500 rounded-md shadow-md"
+                className={`max-w-xs text-sm rounded-md shadow-md border ${typeClassMap[type]}`}
                 role="alert"
             >
                 <div className="flex p-4">
@@ -27,7 +43,7 @@ export const ToastMessage: NextPage<ToastMessageProps> = ({
                         <button
                             type="button"
                             onClick={handleClick}
-                            className="inline-flex flex-shrink-0 justify-center items-center h-4 w-4 rounded-md text-red-400 hover:text-red-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-red-100 focus:ring-red-400 transition-all text-sm"
+                            className={`inline-flex flex-shrink-0 justify-center items-center h-4 w-4 rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 transition-all text-sm ${buttonColorMap[type]}`}
                         >
                             <span className="sr-only">Close</span>
                             <svg

--- a/src/libs/interface/props.ts
+++ b/src/libs/interface/props.ts
@@ -35,6 +35,7 @@ export interface ShareMapProps {
 export interface ToastMessageProps {
     setshowToastMessage: React.Dispatch<React.SetStateAction<boolean>>
     message: string
+    type: 'success' | 'error' | 'info' | 'warning'
     shouldReload: boolean
 }
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -88,12 +88,15 @@ const Home: NextPage = () => {
 
             <section className="flex flex-col items-center justify-center h-screen text-center px-6">
                 <h1 className="text-5xl md:text-6xl font-bold leading-tight tracking-tight">
-                    Manage & Share Locations <br className="hidden md:block" /> with Intuitive
-                    Control
+                    Share Maps Instantly <br className="hidden md:block" />
+                    No Sign-ups for Viewers
                 </h1>
                 <p className="mt-6 text-lg text-gray-700 max-w-xl">
-                    Store and share your locations easily. <br className="hidden md:block" />
-                    Secure authentication with email. No passwords required.
+                    Just pin locations and share with a URL or short code.{' '}
+                    <br className="hidden md:block" />
+                    Anyone can view your map — no login or app needed.{' '}
+                    <br className="hidden md:block" />
+                    You create and manage maps with simple email sign-in.
                 </p>
 
                 <div className="mt-10 flex flex-col items-center">

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -49,6 +49,7 @@ const Home: NextPage = () => {
                             setshowToastMessage={setShowToastMessage}
                             message="You are not signed in."
                             shouldReload={false}
+                            type="error"
                         />
                     )}
                     {router.query.invalidShareCode && (
@@ -56,6 +57,7 @@ const Home: NextPage = () => {
                             setshowToastMessage={setInvalidShareCode}
                             message="Invalid Share Code."
                             shouldReload={true}
+                            type="error"
                         />
                     )}
                     <nav className="flex space-x-6 text-lg text-gray-700">

--- a/src/pages/placemap.tsx
+++ b/src/pages/placemap.tsx
@@ -179,6 +179,7 @@ const MapPage: NextPage<MapPageProps> = ({ places, shareId }) => {
                             setshowToastMessage={setShowToastMessage}
                             message={toastMessage}
                             shouldReload={false}
+                            type="success"
                         />
                     )}
                     <button

--- a/src/pages/placemap.tsx
+++ b/src/pages/placemap.tsx
@@ -20,6 +20,7 @@ import { generateShareCode } from '@/utils/shareCodeGenerator'
 import { replaceSpace } from '@/utils/replaceSpace'
 import { CommonMeta } from '@/components/CommonMeta'
 import { PlaceTable } from '@/components/PlaceTable'
+import { ToastMessage } from '@/components/Toast'
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
     const session = await getServerSession(context.req, context.res, authOptions)
@@ -71,6 +72,8 @@ const MapPage: NextPage<MapPageProps> = ({ places, shareId }) => {
     const [isOpen, setIsOpen] = useState(false)
     const [isLoading, setIsLoading] = useState(false)
     const [isSidebarOpen, setIsSidebarOpen] = useState(false)
+    const [showToastMessage, setShowToastMessage] = useState(false)
+    const [toastMessage, setToastMessage] = useState('')
 
     const Map = React.useMemo(
         () =>
@@ -120,6 +123,19 @@ const MapPage: NextPage<MapPageProps> = ({ places, shareId }) => {
         }
     }
 
+    const handleCopyShareUrl = async () => {
+        try {
+            await navigator.clipboard.writeText(
+                `${process.env.NEXT_PUBLIC_URL}/sharemap?sharecode=${shareCode}`
+            )
+            setToastMessage('URL copied to clipboard!')
+            setShowToastMessage(true)
+        } catch (err) {
+            setToastMessage('Failed to copy URL.')
+            setShowToastMessage(true)
+        }
+    }
+
     const handleGenerateShareCode = async () => {
         if (session) {
             try {
@@ -158,6 +174,13 @@ const MapPage: NextPage<MapPageProps> = ({ places, shareId }) => {
             <CommonMeta title="Owner Map - Place Keeper" />
             <header className="flex items-center w-full h-20 sm:h-16 bg-white shadow-md mb-4">
                 <div className="container flex items-center justify-between px-6 mx-auto">
+                    {showToastMessage && (
+                        <ToastMessage
+                            setshowToastMessage={setShowToastMessage}
+                            message={toastMessage}
+                            shouldReload={false}
+                        />
+                    )}
                     <button
                         className="block md:hidden p-2 rounded-md transition-all duration-200 hover:bg-gray-100"
                         onClick={toggleSidebar}
@@ -206,9 +229,12 @@ const MapPage: NextPage<MapPageProps> = ({ places, shareId }) => {
                                     Email: {session?.user.email}
                                 </div>
                                 {shareCode ? (
-                                    <div className="flex items-center gap-x-3.5 py-2 px-3 rounded-md text-sm text-gray-800 hover:bg-gray-100">
-                                        ShareCode: {shareCode}
-                                    </div>
+                                    <button
+                                        onClick={handleCopyShareUrl}
+                                        className="flex items-center gap-x-3.5 py-2 px-3 rounded-md text-sm text-gray-800 hover:bg-gray-100 w-full text-left"
+                                    >
+                                        Copy Share URL
+                                    </button>
                                 ) : (
                                     <button
                                         onClick={handleGenerateShareCode}


### PR DESCRIPTION
A method to generate shareable URLs has been added, making it easier to view shared maps.
The existing method of entering a share code to access shared maps remains available as well.